### PR TITLE
Add config for commit message convention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+data
+vendor
+composer.lock

--- a/src/Config.php
+++ b/src/Config.php
@@ -29,6 +29,7 @@ class Config
             'security_updates_only' => 0,
             'number_of_concurrent_updates' => 0,
             'branch_prefix' => '',
+            'commit_message_convention' => '',
         ];
     }
 
@@ -135,5 +136,14 @@ class Config
             return (string) $this->config->branch_prefix;
         }
         return '';
+    }
+
+    public function getCommitMessageConvention()
+    {
+        if (!$this->config->commit_message_convention || !is_string($this->config->commit_message_convention)) {
+            return '';
+        }
+
+        return $this->config->commit_message_convention;
     }
 }

--- a/tests/UnitTest.php
+++ b/tests/UnitTest.php
@@ -59,7 +59,7 @@ class UnitTest extends TestCase
     }
 
     /**
-     * Test the blacklist config option.
+     * Test the branch prefix config option.
      *
      * @dataProvider getBranchPrefix
      */
@@ -67,6 +67,17 @@ class UnitTest extends TestCase
     {
         $data = $this->createDataFromFixture($filename);
         self::assertEquals($expected_result, $data->getBranchPrefix());
+    }
+
+    /**
+     * Test the commit message convention config option.
+     *
+     * @dataProvider getCommitMessage
+     */
+    public function testCommitMessage($filename, $expected_result)
+    {
+        $data = $this->createDataFromFixture($filename);
+        self::assertEquals($expected_result, $data->getCommitMessageConvention());
     }
 
     protected function createDataFromFixture($filename)
@@ -93,6 +104,28 @@ class UnitTest extends TestCase
             [
                 'prefix4.json',
                 'my_prefix',
+            ],
+        ];
+    }
+
+    public function getCommitMessage()
+    {
+        return [
+            [
+                'commit_message.json',
+                '',
+            ],
+            [
+                'commit_message2.json',
+                '',
+            ],
+            [
+                'commit_message3.json',
+                '',
+            ],
+            [
+                'commit_message4.json',
+                'conventional',
             ],
         ];
     }

--- a/tests/UnitTest.php
+++ b/tests/UnitTest.php
@@ -80,6 +80,50 @@ class UnitTest extends TestCase
         self::assertEquals($expected_result, $data->getCommitMessageConvention());
     }
 
+    /**
+     * Test the default branch config option.
+     *
+     * @dataProvider getDefaultBranch
+     */
+    public function testDefaultBranch($filename, $expected_result)
+    {
+        $data = $this->createDataFromFixture($filename);
+        self::assertEquals($expected_result, $data->getDefaultBranch());
+    }
+
+    /**
+     * Test the update dev dependencies config option.
+     *
+     * @dataProvider getUpdateDevDependencies
+     */
+    public function testUpdateDevDependencies($filename, $expected_result)
+    {
+        $data = $this->createDataFromFixture($filename);
+        self::assertEquals($expected_result, $data->shouldUpdateDevDependencies());
+    }
+
+    /**
+     * Test the security updates config option.
+     *
+     * @dataProvider getSecurityUpdates
+     */
+    public function testSecurityUpdates($filename, $expected_result)
+    {
+        $data = $this->createDataFromFixture($filename);
+        self::assertEquals($expected_result, $data->shouldOnlyUpdateSecurityUpdates());
+    }
+
+    /**
+     * Test the only direct dependencies config option.
+     *
+     * @dataProvider getOnlyDirectDependencies
+     */
+    public function testOnlyDirectDependencies($filename, $expected_result)
+    {
+        $data = $this->createDataFromFixture($filename);
+        self::assertEquals($expected_result, $data->shouldCheckDirectOnly());
+    }
+
     protected function createDataFromFixture($filename)
     {
         $file_contents = json_decode(file_get_contents(__DIR__ . '/fixtures/' . $filename));
@@ -112,6 +156,10 @@ class UnitTest extends TestCase
     {
         return [
             [
+                'empty.json',
+                '',
+            ],
+            [
                 'commit_message.json',
                 '',
             ],
@@ -121,10 +169,6 @@ class UnitTest extends TestCase
             ],
             [
                 'commit_message3.json',
-                '',
-            ],
-            [
-                'commit_message4.json',
                 'conventional',
             ],
         ];
@@ -261,6 +305,138 @@ class UnitTest extends TestCase
                     "package1",
                     "vendor/*"
                 ],
+            ],
+        ];
+    }
+
+    public function getDefaultBranch()
+    {
+        return [
+            [
+                'empty.json',
+                '',
+            ],
+            [
+                'default_branch.json',
+                '',
+            ],
+            [
+                'default_branch2.json',
+                'develop',
+            ],
+        ];
+    }
+
+    public function getUpdateDevDependencies()
+    {
+        return [
+            [
+                'update_dev_dependencies.json',
+                true,
+            ],
+            [
+                'update_dev_dependencies2.json',
+                true,
+            ],
+            [
+                'update_dev_dependencies3.json',
+                true,
+            ],
+            [
+                'update_dev_dependencies4.json',
+                false,
+            ],
+            [
+                'update_dev_dependencies5.json',
+                true,
+            ],
+            [
+                'update_dev_dependencies6.json',
+                true,
+            ],
+            [
+                'update_dev_dependencies7.json',
+                true,
+            ],
+            [
+                'empty.json',
+                true,
+            ],
+        ];
+    }
+
+    public function getSecurityUpdates()
+    {
+        return [
+            [
+                'security_updates_only.json',
+                true,
+            ],
+            [
+                'security_updates_only2.json',
+                true,
+            ],
+            [
+                'security_updates_only3.json',
+                true,
+            ],
+            [
+                'security_updates_only4.json',
+                false,
+            ],
+            [
+                'security_updates_only5.json',
+                true,
+            ],
+            [
+                'security_updates_only6.json',
+                true,
+            ],
+            [
+                'security_updates_only7.json',
+                true,
+            ],
+            [
+                'empty.json',
+                false,
+            ],
+        ];
+    }
+
+    public function getOnlyDirectDependencies()
+    {
+        return [
+            [
+                'check_only_direct_dependencies.json',
+                true,
+            ],
+            [
+                'check_only_direct_dependencies2.json',
+                true,
+            ],
+            [
+                'check_only_direct_dependencies3.json',
+                true,
+            ],
+            [
+                'check_only_direct_dependencies4.json',
+                false,
+            ],
+            [
+                'check_only_direct_dependencies5.json',
+                true,
+            ],
+            [
+                'check_only_direct_dependencies6.json',
+                true,
+            ],
+            [
+                'check_only_direct_dependencies7.json',
+                true,
+            ],
+            [
+                'empty.json',
+                true,
             ],
         ];
     }

--- a/tests/fixtures/check_only_direct_dependencies.json
+++ b/tests/fixtures/check_only_direct_dependencies.json
@@ -1,0 +1,7 @@
+{
+  "extra": {
+    "violinist": {
+      "check_only_direct_dependencies": 1
+    }
+  }
+}

--- a/tests/fixtures/check_only_direct_dependencies2.json
+++ b/tests/fixtures/check_only_direct_dependencies2.json
@@ -1,0 +1,7 @@
+{
+  "extra": {
+    "violinist": {
+      "check_only_direct_dependencies": "1"
+    }
+  }
+}

--- a/tests/fixtures/check_only_direct_dependencies3.json
+++ b/tests/fixtures/check_only_direct_dependencies3.json
@@ -1,0 +1,7 @@
+{
+  "extra": {
+    "violinist": {
+      "check_only_direct_dependencies": 5
+    }
+  }
+}

--- a/tests/fixtures/check_only_direct_dependencies4.json
+++ b/tests/fixtures/check_only_direct_dependencies4.json
@@ -1,0 +1,7 @@
+{
+  "extra": {
+    "violinist": {
+      "check_only_direct_dependencies": 0
+    }
+  }
+}

--- a/tests/fixtures/check_only_direct_dependencies5.json
+++ b/tests/fixtures/check_only_direct_dependencies5.json
@@ -1,0 +1,7 @@
+{
+  "extra": {
+    "violinist": {
+      "check_only_direct_dependencies": true
+    }
+  }
+}

--- a/tests/fixtures/check_only_direct_dependencies6.json
+++ b/tests/fixtures/check_only_direct_dependencies6.json
@@ -1,0 +1,7 @@
+{
+  "extra": {
+    "violinist": {
+      "check_only_direct_dependencies": "update"
+    }
+  }
+}

--- a/tests/fixtures/check_only_direct_dependencies7.json
+++ b/tests/fixtures/check_only_direct_dependencies7.json
@@ -1,0 +1,9 @@
+{
+  "extra": {
+    "violinist": {
+      "check_only_direct_dependencies": [
+        "update"
+      ]
+    }
+  }
+}

--- a/tests/fixtures/commit_message.json
+++ b/tests/fixtures/commit_message.json
@@ -1,0 +1,7 @@
+{
+  "extra": {
+    "violinist": {
+      "commit_message_convention": ""
+    }
+  }
+}

--- a/tests/fixtures/commit_message2.json
+++ b/tests/fixtures/commit_message2.json
@@ -1,0 +1,6 @@
+{
+  "extra": {
+    "violinist": {
+    }
+  }
+}

--- a/tests/fixtures/commit_message2.json
+++ b/tests/fixtures/commit_message2.json
@@ -1,6 +1,9 @@
 {
   "extra": {
     "violinist": {
+      "commit_message_convention": [
+        "conventional"
+      ]
     }
   }
 }

--- a/tests/fixtures/commit_message3.json
+++ b/tests/fixtures/commit_message3.json
@@ -1,9 +1,7 @@
 {
   "extra": {
     "violinist": {
-      "commit_message_convention": [
-        "conventional"
-      ]
+      "commit_message_convention": "conventional"
     }
   }
 }

--- a/tests/fixtures/commit_message3.json
+++ b/tests/fixtures/commit_message3.json
@@ -1,0 +1,9 @@
+{
+  "extra": {
+    "violinist": {
+      "commit_message_convention": [
+        "conventional"
+      ]
+    }
+  }
+}

--- a/tests/fixtures/commit_message4.json
+++ b/tests/fixtures/commit_message4.json
@@ -1,7 +1,0 @@
-{
-  "extra": {
-    "violinist": {
-      "commit_message_convention": "conventional"
-    }
-  }
-}

--- a/tests/fixtures/commit_message4.json
+++ b/tests/fixtures/commit_message4.json
@@ -1,0 +1,7 @@
+{
+  "extra": {
+    "violinist": {
+      "commit_message_convention": "conventional"
+    }
+  }
+}

--- a/tests/fixtures/default_branch.json
+++ b/tests/fixtures/default_branch.json
@@ -1,0 +1,7 @@
+{
+  "extra": {
+    "violinist": {
+      "default_branch": ""
+    }
+  }
+}

--- a/tests/fixtures/default_branch2.json
+++ b/tests/fixtures/default_branch2.json
@@ -1,0 +1,7 @@
+{
+  "extra": {
+    "violinist": {
+      "default_branch": "develop"
+    }
+  }
+}

--- a/tests/fixtures/security_updates_only.json
+++ b/tests/fixtures/security_updates_only.json
@@ -1,0 +1,7 @@
+{
+  "extra": {
+    "violinist": {
+      "security_updates_only": 1
+    }
+  }
+}

--- a/tests/fixtures/security_updates_only2.json
+++ b/tests/fixtures/security_updates_only2.json
@@ -1,0 +1,7 @@
+{
+  "extra": {
+    "violinist": {
+      "security_updates_only": "1"
+    }
+  }
+}

--- a/tests/fixtures/security_updates_only3.json
+++ b/tests/fixtures/security_updates_only3.json
@@ -1,0 +1,7 @@
+{
+  "extra": {
+    "violinist": {
+      "security_updates_only": 5
+    }
+  }
+}

--- a/tests/fixtures/security_updates_only4.json
+++ b/tests/fixtures/security_updates_only4.json
@@ -1,0 +1,7 @@
+{
+  "extra": {
+    "violinist": {
+      "security_updates_only": 0
+    }
+  }
+}

--- a/tests/fixtures/security_updates_only5.json
+++ b/tests/fixtures/security_updates_only5.json
@@ -1,0 +1,7 @@
+{
+  "extra": {
+    "violinist": {
+      "security_updates_only": true
+    }
+  }
+}

--- a/tests/fixtures/security_updates_only6.json
+++ b/tests/fixtures/security_updates_only6.json
@@ -1,0 +1,7 @@
+{
+  "extra": {
+    "violinist": {
+      "security_updates_only": "update"
+    }
+  }
+}

--- a/tests/fixtures/security_updates_only7.json
+++ b/tests/fixtures/security_updates_only7.json
@@ -1,0 +1,9 @@
+{
+  "extra": {
+    "violinist": {
+      "security_updates_only": [
+        "update"
+      ]
+    }
+  }
+}

--- a/tests/fixtures/update_dev_dependencies.json
+++ b/tests/fixtures/update_dev_dependencies.json
@@ -1,0 +1,7 @@
+{
+  "extra": {
+    "violinist": {
+      "update_dev_dependencies": 1
+    }
+  }
+}

--- a/tests/fixtures/update_dev_dependencies2.json
+++ b/tests/fixtures/update_dev_dependencies2.json
@@ -1,0 +1,7 @@
+{
+  "extra": {
+    "violinist": {
+      "update_dev_dependencies": "1"
+    }
+  }
+}

--- a/tests/fixtures/update_dev_dependencies3.json
+++ b/tests/fixtures/update_dev_dependencies3.json
@@ -1,0 +1,7 @@
+{
+  "extra": {
+    "violinist": {
+      "update_dev_dependencies": 5
+    }
+  }
+}

--- a/tests/fixtures/update_dev_dependencies4.json
+++ b/tests/fixtures/update_dev_dependencies4.json
@@ -1,0 +1,7 @@
+{
+  "extra": {
+    "violinist": {
+      "update_dev_dependencies": 0
+    }
+  }
+}

--- a/tests/fixtures/update_dev_dependencies5.json
+++ b/tests/fixtures/update_dev_dependencies5.json
@@ -1,0 +1,7 @@
+{
+  "extra": {
+    "violinist": {
+      "update_dev_dependencies": true
+    }
+  }
+}

--- a/tests/fixtures/update_dev_dependencies6.json
+++ b/tests/fixtures/update_dev_dependencies6.json
@@ -1,0 +1,7 @@
+{
+  "extra": {
+    "violinist": {
+      "update_dev_dependencies": "update"
+    }
+  }
+}

--- a/tests/fixtures/update_dev_dependencies7.json
+++ b/tests/fixtures/update_dev_dependencies7.json
@@ -1,0 +1,9 @@
+{
+  "extra": {
+    "violinist": {
+      "update_dev_dependencies": [
+        "update"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Hello Eirik! 🙂

This is the new config for commit message. I also increased the coverage. I hope it's ok.
However, I saw some problems with some config types like default branch. If the composer.json provides an empty value (string or array), the method returns false and not the default value (empty string). If it provides a not empty array, the method returns this one. There are other methods with this kind of problem. I don't know if it's intentional, so I didn't touch that, but I can fix it in another PR if you want.

👋
