### PR TITLE
feat: Add new config option allow_security_updates_on_concurrent_limit

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -33,6 +33,7 @@ class Config
             'run_scripts' => 1,
             'security_updates_only' => 0,
             'number_of_concurrent_updates' => 0,
+            'allow_security_updates_on_concurrent_limit' => 0,
             'branch_prefix' => '',
             'commit_message_convention' => '',
             'allow_update_indirect_with_direct' => 0,
@@ -287,6 +288,11 @@ class Config
     public function getNumberOfAllowedPrs()
     {
         return (int) $this->config->number_of_concurrent_updates;
+    }
+
+    public function shouldAllowSecurityUpdatesOnConcurrentLimit()
+    {
+        return (bool) $this->config->allow_security_updates_on_concurrent_limit;
     }
 
     public function shouldOnlyUpdateSecurityUpdates()

--- a/tests/UnitTest.php
+++ b/tests/UnitTest.php
@@ -320,6 +320,17 @@ class UnitTest extends TestCase
     }
 
     /**
+     * Test the allow_security_updates_on_concurrent_limit config option.
+     *
+     * @dataProvider getAllowSecurityUpdatesOnConcurrentLimitDataProvider
+     */
+    public function testAllowSecurityUpdatesOnConcurrentLimit($filename, $expected_result)
+    {
+        $data = $this->createDataFromFixture($filename);
+        self::assertEquals($expected_result, $data->shouldAllowSecurityUpdatesOnConcurrentLimit());
+    }
+
+    /**
      * Test the only direct dependencies config option.
      *
      * @dataProvider getOnlyDirectDependencies
@@ -1234,6 +1245,18 @@ class UnitTest extends TestCase
                 'empty.json',
                 false,
             ],
+        ];
+    }
+
+    /**
+     * Data provider for testAllowSecurityUpdatesOnConcurrentLimit.
+     */
+    public function getAllowSecurityUpdatesOnConcurrentLimitDataProvider()
+    {
+        return [
+            ['empty.json', false],
+            ['allow_security_updates_on_concurrent_limit.json', true],
+            ['allow_security_updates_on_concurrent_limit1.json', false],
         ];
     }
 

--- a/tests/fixtures/allow_security_updates_on_concurrent_limit.json
+++ b/tests/fixtures/allow_security_updates_on_concurrent_limit.json
@@ -1,0 +1,8 @@
+{
+  "extra": {
+    "violinist": {
+      "number_of_concurrent_updates": 1,
+      "allow_security_updates_on_concurrent_limit": 1
+    }
+  }
+}

--- a/tests/fixtures/allow_security_updates_on_concurrent_limit1.json
+++ b/tests/fixtures/allow_security_updates_on_concurrent_limit1.json
@@ -1,0 +1,8 @@
+{
+  "extra": {
+    "violinist": {
+      "number_of_concurrent_updates": 1,
+      "allow_security_updates_on_concurrent_limit": 0
+    }
+  }
+}


### PR DESCRIPTION
## Why
We want to get security packages passed on `number_of_concurrent_updates` by default. But for those who want to save CI minutes or not doing it can feel free disable the `skip_security_updates_on_concurrent_limit` 