### PR TITLE
test: add regression test for merged violinist config from multi-level extends

### DIFF
--- a/tests/VersionThree/MergedConfigValidationTest.php
+++ b/tests/VersionThree/MergedConfigValidationTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Violinist\Config\Tests\VersionThree;
+
+use PHPUnit\Framework\TestCase;
+use Violinist\Config\Config;
+
+class MergedConfigValidationTest extends TestCase
+{
+    public function testFinalMergedOutputIsCorrect()
+    {
+        $temp_folder = sys_get_temp_dir() . '/' . uniqid('ViolinistMergedTest_', true);
+        mkdir($temp_folder, 0777, true);
+
+        // Root config that extends shared-violinist-drupal
+        $composer_data = (object) [
+            'extra' => (object) [
+                'violinist' => (object) [
+                    'extends' => 'vendor/shared-violinist-drupal',
+                ],
+            ],
+        ];
+        file_put_contents("$temp_folder/composer.json", json_encode($composer_data));
+
+        // Mock vendor structure
+        mkdir("$temp_folder/vendor/vendor/shared-violinist-drupal", 0777, true);
+        mkdir("$temp_folder/vendor/vendor/shared-violinist-common", 0777, true);
+
+        // Copy fixture configs
+        copy(__DIR__ . '/../fixtures/level1.json', "$temp_folder/vendor/vendor/shared-violinist-drupal/composer.json");
+        copy(__DIR__ . '/../fixtures/violinist-drupal-config.json', "$temp_folder/vendor/vendor/shared-violinist-drupal/violinist-drupal-config.json");
+        copy(__DIR__ . '/../fixtures/level2.json', "$temp_folder/vendor/vendor/shared-violinist-common/composer.json");
+        copy(__DIR__ . '/../fixtures/violinist-base-config.json', "$temp_folder/vendor/vendor/shared-violinist-common/violinist-base-config.json");
+
+        // Create config
+        $config = Config::createFromComposerPath("$temp_folder/composer.json");
+
+        // Load expected result
+        $expected = json_decode(file_get_contents(__DIR__ . '/../fixtures/violinist-expected-config.json'));
+
+        // Compare final resolved config with expected
+        $this->assertEquals($expected, json_decode(json_encode($config->getConfig())));
+    }
+}

--- a/tests/VersionThree/MergedConfigValidationTest.php
+++ b/tests/VersionThree/MergedConfigValidationTest.php
@@ -39,6 +39,6 @@ class MergedConfigValidationTest extends TestCase
         $expected = json_decode(file_get_contents(__DIR__ . '/../fixtures/violinist-expected-config.json'));
 
         // Compare final resolved config with expected
-        $this->assertEquals($expected, json_decode(json_encode($config->getConfig())));
+        $this->assertEquals($expected, json_decode(json_encode($config->config)));
     }
 }

--- a/tests/fixtures/violinist-expected-config.json
+++ b/tests/fixtures/violinist-expected-config.json
@@ -1,0 +1,38 @@
+{
+  "allow_list": [
+    "drupal/*",
+    "drush/drush",
+    "frontkom/*",
+    "nymediaas/*",
+    "roave/security-advisories",
+    "thunderer/*"
+  ],
+  "always_allow_direct_dependencies": true,
+  "automerge": true,
+  "automerge_method": "squash",
+  "bundled_packages": {
+    "drupal/core-recommended": [
+      "drupal/core-composer-scaffold",
+      "drupal/core-dev",
+      "drupal/core",
+      "drush/drush"
+    ]
+  },
+  "blocklist": [
+    "drupal/core-composer-scaffold",
+    "drupal/core-dev",
+    "drupal/core"
+  ],
+  "branch_prefix": "violinist/",
+  "check_only_direct_dependencies": false,
+  "commit_message_convention": "conventional",
+  "labels": [
+    "dependencies"
+  ],
+  "labels_security": [
+    "dependencies",
+    "security"
+  ],
+  "number_of_concurrent_updates": 5,
+  "allow_security_updates_on_concurrent_limit": true
+}


### PR DESCRIPTION
This PR adds a PHPUnit test to validate that `violinist` config merging works as expected when using multi-level `extends` directives across packages.

The test builds a mock environment simulating nested shared configurations (`shared-violinist-drupal` and `shared-violinist-common`), then verifies that the final resolved configuration matches a canonical expected JSON.

The expected config is stored in `tests/fixtures/violinist-expected-config.json` and represents the result of merging:

- "`violinist-base-config.json` (base)"
- "`violinist-drupal-config.json` (extends base)"
- "a root-level composer.json (extends drupal config)"

This ensures we catch regressions in how the config is extended and combined across packages.

